### PR TITLE
Add `allowsDefaultTighteningForTruncation` to paragraph style

### DIFF
--- a/schema/objects/paragraph-style.schema.yaml
+++ b/schema/objects/paragraph-style.schema.yaml
@@ -10,3 +10,4 @@ properties:
   maximumLineHeight: { type: number }
   minimumLineHeight: { type: number }
   paragraphSpacing: { type: number }
+  allowsDefaultTighteningForTruncation: { type: number }


### PR DESCRIPTION
This PR adds the `allowsDefaultTighteningForTruncation` property to the `objects/paragraph-style` schema.

Fixes #20 
