### PR TITLE
Bug/23 incorrect class name for inner shadows

### DIFF
--- a/schema/objects/inner-shadow.schema.yaml
+++ b/schema/objects/inner-shadow.schema.yaml
@@ -2,7 +2,7 @@ title: Inner Shadow
 description: Defines an inner shadow style
 type: object
 properties:
-  _class: { const: shadow }
+  _class: { const: innerShadow }
   isEnabled: { type: boolean }
   blurRadius: { type: number }
   color: { $ref: ./color.schema.yaml }

--- a/schema/objects/paragraph-style.schema.yaml
+++ b/schema/objects/paragraph-style.schema.yaml
@@ -10,3 +10,4 @@ properties:
   maximumLineHeight: { type: number }
   minimumLineHeight: { type: number }
   paragraphSpacing: { type: number }
+  allowsDefaultTighteningForTruncation: { type: number }


### PR DESCRIPTION
While the spec states that `inner-shadow` should have a `_class` of `shadow`, files created with Sketch 59.1 have a class of `innerShadow`.

Fixes #23 