### PR TITLE
Add optional `sharedStyleID` to `abstract-layer` schema 

### DIFF
--- a/schema/layers/abstract-layer.schema.yaml
+++ b/schema/layers/abstract-layer.schema.yaml
@@ -7,6 +7,7 @@ optional:
   - hasClippingMask
   - clippingMaskMode
   - style
+  - sharedStyleID
 properties:
   do_objectID: { $ref: ../utils/uuid.schema.yaml }
   booleanOperation: { $ref: ../enums/boolean-operation.schema.yaml }
@@ -28,6 +29,7 @@ properties:
     maximum: 127
   resizingType: { $ref: ../enums/resize-type.schema.yaml }
   rotation: { type: number }
+  sharedStyleID: { $ref: ../utils/uuid.schema.yaml }
   shouldBreakMaskChain: { type: boolean }
   hasClippingMask: { type: boolean }
   clippingMaskMode: { type: integer }

--- a/schema/objects/paragraph-style.schema.yaml
+++ b/schema/objects/paragraph-style.schema.yaml
@@ -10,3 +10,4 @@ properties:
   maximumLineHeight: { type: number }
   minimumLineHeight: { type: number }
   paragraphSpacing: { type: number }
+  allowsDefaultTighteningForTruncation: { type: number }


### PR DESCRIPTION
The abstract layer schema is missing the sharedStyleID property that's used to link a layer to a given shared style.

Fixes https://github.com/sketch-hq/sketch-file-format/issues/25