### PR TITLE
Bump packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "json",
     "json schema"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "dependencies": {
     "@types/json-schema": "7.0.4"
   },
@@ -31,6 +33,7 @@
     "chalk": "3.0.0",
     "change-case": "4.1.1",
     "deepdash": "4.5.1",
+    "dot-prop": "4.2.1",
     "globby": "11.0.0",
     "js-yaml": "3.13.1",
     "json-schema-merge-allof": "0.6.0",
@@ -38,7 +41,8 @@
     "lodash": "4.17.15",
     "node-stream-zip": "1.9.1",
     "prettier": "1.19.1",
-    "typescript": "3.8.1-rc"
+    "typescript": "3.8.1-rc",
+    "yargs-parser": "18.1.2"
   },
   "scripts": {
     "build": "yarn build:schemas && yarn build:pkg",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1125,6 +1125,13 @@ dot-case@^3.0.3:
     no-case "^3.0.3"
     tslib "^1.10.0"
 
+dot-prop@4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-4.2.1.tgz#45884194a71fc2cda71cbb4bceb3a4dd2f433ba4"
+  integrity sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==
+  dependencies:
+    is-obj "^1.0.0"
+
 dot-prop@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-3.0.0.tgz#1b708af094a49c9a0e7dbcad790aba539dac1177"
@@ -3216,6 +3223,14 @@ yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
   integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
+
+yargs-parser@18.1.2:
+  version "18.1.2"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.2.tgz#2f482bea2136dbde0861683abea7756d30b504f1"
+  integrity sha512-hlIPNR3IzC1YuL1c2UwwDKpXlNFBqD1Fswwh1khz5+d8Cq/8yc/Mn0i+rQXduu8hcrFKvO7Eryk+09NecTQAAQ==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
 
 yargs-parser@^10.0.0:
   version "10.1.0"


### PR DESCRIPTION
This is a manual PR.

As discussed in Slack, I've checked that:

- `yarn build` still works, and builds the packages correctly
- the output of the build command is not affected by the package update, and only `package.json`, `yarn.lock` and `node_modules` are changed:

<img width="1119" alt="Screenshot 2020-09-06 at 17 32 05" src="https://user-images.githubusercontent.com/3832/92329371-4ea5ae00-f067-11ea-85ef-ba4ea9bc3ccb.png">
