### PR TITLE
Coedit patch info schemas

### DIFF
--- a/.changeset/healthy-monkeys-double.md
+++ b/.changeset/healthy-monkeys-double.md
@@ -1,0 +1,5 @@
+---
+'@sketch-hq/sketch-file-format': patch
+---
+
+Add schemas for coedit patch info.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,6 +9,6 @@
   "yaml.schemas": {
     "http://json-schema.org/draft-07/schema": "*.schema.yaml"
   },
-  "yaml.completion": true,
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "prettier.enable": true
 }

--- a/schema/enums/co-edit-status.schema.yaml
+++ b/schema/enums/co-edit-status.schema.yaml
@@ -1,6 +1,5 @@
 title: Collaborative Editing Status
-description:
-  Enumeration of the possible collaborative editing status strings.
+description: Enumeration of the possible collaborative editing status strings.
 type: string
 enum:
   - COLLABORATING

--- a/schema/enums/co-edit-status.schema.yaml
+++ b/schema/enums/co-edit-status.schema.yaml
@@ -1,0 +1,12 @@
+title: Collaborative Editing Status
+description:
+  Enumeration of the possible collaborative editing status strings.
+type: string
+enum:
+  - COLLABORATING
+  - LOCAL
+  - INITIAL
+enumDescriptions:
+  - Collaborating
+  - Local
+  - Initial

--- a/schema/objects/co-edit-status-info.schema.yaml
+++ b/schema/objects/co-edit-status-info.schema.yaml
@@ -1,0 +1,8 @@
+title: Collaborative Editing Status Info
+description:
+  Object containing status information about collaborative editing.
+type: object
+properties:
+  _class: { const: SharedEditing.MSCoEditStatusInfo }
+  shareID: { $ref: ../utils/uuid.schema.yaml }
+  statusString: { type: string }

--- a/schema/objects/co-edit-status-info.schema.yaml
+++ b/schema/objects/co-edit-status-info.schema.yaml
@@ -1,6 +1,5 @@
 title: Collaborative Editing Status Info
-description:
-  Object containing status information about collaborative editing.
+description: Object containing status information about collaborative editing.
 type: object
 properties:
   _class: { const: SharedEditing.MSCoEditStatusInfo }

--- a/schema/objects/document-state.schema.yaml
+++ b/schema/objects/document-state.schema.yaml
@@ -4,3 +4,7 @@ description:
   and will see additions in future document versions.
 type: object
 additionalProperties: true
+optional:
+  - patchInfo
+properties:
+  patchInfo: { $ref: ./patch-info.schema.yaml }

--- a/schema/objects/file-ref.schema.yaml
+++ b/schema/objects/file-ref.schema.yaml
@@ -8,7 +8,9 @@ properties:
     enum:
       - MSImageData
       - MSImmutablePage
+      - MSPatch
     enumDescriptions:
       - MSImageData
       - MSImmutablePage
+      - MSPatch
   _ref: { type: string }

--- a/schema/objects/patch-info.schema.yaml
+++ b/schema/objects/patch-info.schema.yaml
@@ -12,3 +12,6 @@ properties:
   localPatches:
     type: array
     items: { $ref: ./file-ref.schema.yaml }
+  receivedPatches:
+     type: array
+     items: { $ref: ./file-ref.schema.yaml }

--- a/schema/objects/patch-info.schema.yaml
+++ b/schema/objects/patch-info.schema.yaml
@@ -12,4 +12,3 @@ properties:
   localPatches:
     type: array
     items: { $ref: ./file-ref.schema.yaml }
-  

--- a/schema/objects/patch-info.schema.yaml
+++ b/schema/objects/patch-info.schema.yaml
@@ -13,5 +13,5 @@ properties:
     type: array
     items: { $ref: ./file-ref.schema.yaml }
   receivedPatches:
-     type: array
-     items: { $ref: ./file-ref.schema.yaml }
+    type: array
+    items: { $ref: ./file-ref.schema.yaml }

--- a/schema/objects/patch-info.schema.yaml
+++ b/schema/objects/patch-info.schema.yaml
@@ -1,0 +1,15 @@
+title: Patch Info
+description:
+  Defines ephemeral patch information related to the Cloud collaborative editing
+  feature. This information will only be found behind-the-scenes in Cloud
+  documents and won't be relevant or visible to users parsing or generating
+  their own Sketch documents.
+type: object
+properties:
+  _class: { const: MSImmutablePatchInfo }
+  status: { $ref: ./co-edit-status-info.schema.yaml }
+  lastIntegratedPatchID: { $ref: ../utils/uuid.schema.yaml }
+  localPatches:
+    type: array
+    items: { $ref: ./file-ref.schema.yaml }
+  


### PR DESCRIPTION
Adds schemas for the `patchInfo` property in `document-state.schema.yaml`. Although `patchInfo` is effectively hidden from ordinary users, only appearing in Cloud Documents behind-the-scenes I felt it makes sense to fully document the data structure in the schemas - this should make the schemas maximally useful in future, in case we are able to integrate them more tightly with Sketch.

### Referenced issues

Fixes #94 