### PR TITLE
Fix overrideName regex to support layerStyle and nested symbols

### DIFF
--- a/.changeset/gentle-eels-travel.md
+++ b/.changeset/gentle-eels-travel.md
@@ -1,0 +1,5 @@
+---
+'@sketch-hq/sketch-file-format': patch
+---
+
+Fix overrideName regex to support layerStyle and nested symbols

--- a/schema/objects/override-name.schema.yaml
+++ b/schema/objects/override-name.schema.yaml
@@ -2,8 +2,10 @@ title: Override Name
 description: Defines the valid string patterns for an override name
 oneOf:
   - type: string
-    pattern: '^[0-9A-F]{8}\-[0-9A-F]{4}\-[0-9A-F]{4}\-[0-9A-F]{4}\-[0-9A-F]{12}_stringValue$'
+    pattern: '[0-9A-F]{8}\-[0-9A-F]{4}\-[0-9A-F]{4}\-[0-9A-F]{4}\-[0-9A-F]{12}((_stringValue$)|\/)'
   - type: string
-    pattern: '^[0-9A-F]{8}\-[0-9A-F]{4}\-[0-9A-F]{4}\-[0-9A-F]{4}\-[0-9A-F]{12}_symbolID$'
+    pattern: '[0-9A-F]{8}\-[0-9A-F]{4}\-[0-9A-F]{4}\-[0-9A-F]{4}\-[0-9A-F]{12}((_symbolID$)|\/)'
   - type: string
-    pattern: '^[0-9A-F]{8}\-[0-9A-F]{4}\-[0-9A-F]{4}\-[0-9A-F]{4}\-[0-9A-F]{12}_image$'
+    pattern: '[0-9A-F]{8}\-[0-9A-F]{4}\-[0-9A-F]{4}\-[0-9A-F]{4}\-[0-9A-F]{12}((_image$)|\/)'
+  - type: string
+    pattern: '[0-9A-F]{8}\-[0-9A-F]{4}\-[0-9A-F]{4}\-[0-9A-F]{4}\-[0-9A-F]{12}((_layerStyle$)|\/)'


### PR DESCRIPTION
Adds support to layerStyles and updates existent patterns to support nested symbols.

### Referenced issues
Fixes #123 