### PR TITLE
Use schemas as direct dependencies

### DIFF
--- a/packages/file-format-ts/package.json
+++ b/packages/file-format-ts/package.json
@@ -18,10 +18,12 @@
     "typescript",
     "types"
   ],
-  "devDependencies": {
+  "dependencies": {
     "@sketch-hq/sketch-file-format-1": "npm:@sketch-hq/sketch-file-format@1.1.7",
     "@sketch-hq/sketch-file-format-2": "npm:@sketch-hq/sketch-file-format@2.0.3",
-    "@sketch-hq/sketch-file-format": "3.7.3",
+    "@sketch-hq/sketch-file-format": "3.7.3"
+  },
+  "devDependencies": {
     "@types/humps": "2.0.0",
     "humps": "2.0.1",
     "ts-node": "9.1.1"


### PR DESCRIPTION
Move `sketch-file-format` dependencies out of `devDependencies`.